### PR TITLE
fix(plugin-meetings): meeting transcription UT revamp

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -4758,6 +4758,7 @@ export default class Meeting extends StatelessWebexPlugin {
       LoggerProxy.logger.error(
         `Meeting:index#startTranscription --> meeting joined : ${this.isJoined()}`
       );
+      throw new Error('Meeting is not joined');
     }
   }
 
@@ -4854,7 +4855,7 @@ export default class Meeting extends StatelessWebexPlugin {
     Trigger.trigger(
       this,
       {
-        file: 'meeting',
+        file: 'meeting/index',
         function: 'triggerStopReceivingTranscriptionEvent',
       },
       EVENT_TRIGGERS.MEETING_STOPPED_RECEIVING_TRANSCRIPTION


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [SPARK-492442](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-492442)

## This pull request addresses

We recently pushed changes to transcription in meetings from old one to new Voicea transcriptions. However, the UTs for the same were not taken care of

## by making the following changes

This PR removes all the old tests and updated the ones wherever required. In addition, the UTs now also test if the events to the end user are triggered appropriately

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios where tested

< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

### I certified that

- [x] I have read and followed [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
- [x] I discussed changes with code owners prior to submitting this pull request

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the documentation accordingly

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
